### PR TITLE
F28: slide layouts and deck themes in the editor (FR-3, FR-4)

### DIFF
--- a/frontend/src/components/editor/AccessibilityDialog.tsx
+++ b/frontend/src/components/editor/AccessibilityDialog.tsx
@@ -15,6 +15,7 @@ const KIND_LABEL: Record<A11yIssue["kind"], string> = {
   "alt-text": "Alt text",
   "small-text": "Small text",
   "touch-target": "Target size",
+  "slide-title": "Slide titles",
 };
 
 export function AccessibilityDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
@@ -30,8 +31,12 @@ export function AccessibilityDialog({ open, onClose }: { open: boolean; onClose:
   const jump = (i: A11yIssue) => {
     const st = useEditor.getState();
     st.setActivePage(i.pageIndex);
-    st.select([i.nodeId]);
-    st.zoomToSelection();
+    // A slide-title issue points at a PAGE, not a node: there is nothing to
+    // select or zoom to, so just navigate to the slide.
+    if (i.kind !== "slide-title") {
+      st.select([i.nodeId]);
+      st.zoomToSelection();
+    }
     onClose();
   };
 
@@ -41,7 +46,7 @@ export function AccessibilityDialog({ open, onClose }: { open: boolean; onClose:
         <div className="flex flex-col items-center gap-2 py-8 text-center">
           <CheckCircle2 size={36} className="text-emerald-500" />
           <p className="text-sm font-medium text-neutral-700">No accessibility issues found</p>
-          <p className="max-w-xs text-xs text-neutral-400">Text contrast, image alt text, and text size all look good.</p>
+          <p className="max-w-xs text-xs text-neutral-400">Text contrast, image alt text, text size, and slide titles all look good.</p>
         </div>
       ) : (
         <div className="flex flex-col gap-3">
@@ -64,7 +69,10 @@ export function AccessibilityDialog({ open, onClose }: { open: boolean; onClose:
                   <span className="min-w-0 flex-1">
                     <span className="block text-sm text-neutral-800">{i.message}</span>
                     <span className="block truncate text-xs text-neutral-400">
-                      {KIND_LABEL[i.kind]} · {i.nodeName || "element"} · page {i.pageIndex + 1}
+                      {/* A slide-title issue is about the PAGE, not an element on it. */}
+                      {i.kind === "slide-title"
+                        ? `${KIND_LABEL[i.kind]} · slide ${i.pageIndex + 1}`
+                        : `${KIND_LABEL[i.kind]} · ${i.nodeName || "element"} · page ${i.pageIndex + 1}`}
                     </span>
                   </span>
                 </button>

--- a/frontend/src/components/editor/PropertiesPanel.tsx
+++ b/frontend/src/components/editor/PropertiesPanel.tsx
@@ -307,6 +307,7 @@ function VideoSection({ node }: { node: Node }) {
 }
 const chipCls = (active: boolean) => `rounded-md px-2.5 py-1 text-xs font-medium transition ${active ? "bg-surface text-brand-ink shadow-sm" : "text-neutral-500 hover:text-neutral-700"}`;
 const selectCls = "w-full rounded-lg border border-neutral-200 bg-surface px-2 py-1.5 text-sm text-neutral-800 outline-none transition focus:border-brand-400 focus:ring-2 focus:ring-brand-100";
+const actionBtnCls = "w-full rounded-lg border border-neutral-200 bg-surface px-2 py-1.5 text-sm font-medium text-neutral-700 transition hover:bg-neutral-50";
 const inputCls = "w-full rounded-lg border border-neutral-200 bg-surface px-2 py-1.5 text-sm text-neutral-800 outline-none transition focus:border-brand-400 focus:ring-2 focus:ring-brand-100";
 
 function runColorHex(style: CharStyle): string {
@@ -573,6 +574,8 @@ export function PropertiesPanel() {
             </Section>
           );
         })()}
+        <PageLayoutSection page={page} />
+        <DeckThemeSection />
         <PageTransitionSection page={page} />
         <PagePresentSection page={page} />
       </Wrap>
@@ -2045,6 +2048,120 @@ function InteractionSection({ node, doc }: { node: Node; doc: DesignFile }) {
 }
 
 /** Per-page transition control shown in the empty-selection page panel. */
+/** Slide layout picker (doc 28 FR-3). Assigning a layout gives the page a
+ *  placeholder cascade, including the title placeholder that makes its name a
+ *  real, screen-reader-navigable slide title. Installing the built-in layouts
+ *  is itself one undoable action, so a deck opts in explicitly. */
+function PageLayoutSection({ page }: { page: Page }) {
+  const st = useEditor.getState();
+  const rev = useEditor((s) => s.rev);
+  const doc = useEditor.getState().doc as unknown as {
+    layouts?: { id: string; name: string }[];
+  };
+  const layouts = doc.layouts ?? [];
+  const current = (page as { layoutId?: string }).layoutId;
+  // Resolve against the live doc so a deleted layout shows as "None".
+  const known = layouts.some((l) => l.id === current);
+  void rev; // re-render when the deck's layouts change
+
+  if (!layouts.length) {
+    return (
+      <Section title="Layout">
+        <p className="mb-2 text-[11px] leading-relaxed text-neutral-500">
+          Slide layouts give each slide a title and content placeholders, and make slide titles readable by screen
+          readers.
+        </p>
+        <button type="button" onClick={() => st.ensureSlideLayouts()} className={actionBtnCls} data-testid="add-layouts">
+          Add slide layouts
+        </button>
+      </Section>
+    );
+  }
+  return (
+    <Section title="Layout">
+      <select
+        value={known ? current : "none"}
+        onChange={(e) => st.setPageLayout(e.target.value === "none" ? undefined : e.target.value)}
+        className={selectCls}
+        data-testid="layout-select"
+        aria-label="Slide layout"
+      >
+        <option value="none">None</option>
+        {layouts.map((l) => (
+          <option key={l.id} value={l.id}>
+            {l.name}
+          </option>
+        ))}
+      </select>
+      <p className="mt-1.5 text-[11px] text-neutral-500">
+        The layout supplies this slide&apos;s title and content regions.
+      </p>
+    </Section>
+  );
+}
+
+/** Deck theme swap (doc 28 FR-4). Adopting a theme restyles the deck's palette
+ *  and font pair in one undoable action; it never rewrites page content, which
+ *  is what keeps it reversible (recoloring nodes is the Brand panel's re-skin). */
+const BUILTIN_THEMES: { id: string; name: string; colors: string[]; fontHeading: string; fontBody: string }[] = [
+  { id: "theme-plum", name: "Plum", colors: ["#9B2C72", "#C84B9A", "#3E1030", "#FBEFF7", "#18181b", "#ffffff"], fontHeading: "Plus Jakarta Sans", fontBody: "Plus Jakarta Sans" },
+  { id: "theme-slate", name: "Slate", colors: ["#0f172a", "#334155", "#64748b", "#e2e8f0", "#020617", "#ffffff"], fontHeading: "Inter", fontBody: "Inter" },
+  { id: "theme-forest", name: "Forest", colors: ["#14532d", "#16a34a", "#4ade80", "#dcfce7", "#052e16", "#ffffff"], fontHeading: "Inter", fontBody: "Inter" },
+];
+
+function DeckThemeSection() {
+  const st = useEditor.getState();
+  const rev = useEditor((s) => s.rev);
+  const doc = useEditor.getState().doc as unknown as { theme?: { id: string } };
+  const current = doc.theme?.id;
+  void rev;
+  return (
+    <Section title="Deck theme">
+      <div className="flex flex-col gap-1.5" role="radiogroup" aria-label="Deck theme">
+        {BUILTIN_THEMES.map((t) => {
+          const active = current === t.id;
+          return (
+            <button
+              key={t.id}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              data-testid={`theme-${t.id}`}
+              onClick={() =>
+                st.setDeckTheme({
+                  id: t.id,
+                  name: t.name,
+                  colors: t.colors.map((hex, i) => ({ id: `${t.id}-${i}`, color: colorFromHex(hex) })),
+                  fontHeading: t.fontHeading,
+                  fontBody: t.fontBody,
+                })
+              }
+              className={`flex items-center gap-2 rounded-lg border px-2 py-1.5 text-left text-sm transition ${
+                active ? "border-brand-500 bg-brand-50 text-brand-ink" : "border-neutral-200 hover:bg-neutral-50"
+              }`}
+            >
+              <span className="flex shrink-0 gap-0.5">
+                {t.colors.slice(0, 4).map((c) => (
+                  <span key={c} style={{ background: c }} className="h-4 w-2.5 rounded-sm ring-1 ring-black/10" />
+                ))}
+              </span>
+              <span className="min-w-0 flex-1 truncate">{t.name}</span>
+            </button>
+          );
+        })}
+        {current && (
+          <button type="button" onClick={() => st.setDeckTheme(undefined)} className="mt-0.5 text-left text-[11px] text-neutral-500 hover:underline" data-testid="clear-theme">
+            Clear theme
+          </button>
+        )}
+      </div>
+      <p className="mt-1.5 text-[11px] leading-relaxed text-neutral-500">
+        Themes set the deck&apos;s palette and fonts. Your slide content is not restyled.
+      </p>
+    </Section>
+  );
+}
+
 function PageTransitionSection({ page }: { page: Page }) {
   const st = useEditor.getState();
   const t = (page as { transition?: import("@hc/schema").PageTransition }).transition;

--- a/frontend/src/store/editor.ts
+++ b/frontend/src/store/editor.ts
@@ -29,6 +29,9 @@ import {
   type NodeType,
   type Page,
   type PageTransition,
+  type Theme,
+  applyTheme,
+  builtinMasterAndLayouts,
   type Paragraph,
   type ParagraphStyle,
   type Stroke,
@@ -603,6 +606,12 @@ interface EditorState {
   setPageTransition(transition: PageTransition | undefined, pageIndex?: number): void;
   /** Set the active (or given) page's speaker notes, undoable. */
   setPageNotes(notes: string, pageIndex?: number): void;
+  /** Assign (or clear) the slide layout this page inherits (doc 28 FR-3). */
+  setPageLayout(layoutId: string | undefined, pageIndex?: number): void;
+  /** Install the built-in master + layouts on a deck that has none (FR-3). */
+  ensureSlideLayouts(): void;
+  /** Adopt a theme for the whole deck in one undoable action (FR-4). */
+  setDeckTheme(theme: Theme | undefined): void;
   /** Set/clear the active (or given) page's autopilot dwell in ms;
    *  pass null to clear (fall back to the global default). Undoable. */
   setPageAutoAdvance(ms: number | null, pageIndex?: number): void;
@@ -2607,6 +2616,48 @@ export const useEditor = create<EditorState>((set, get) => {
       perform(
         () => { page.transition = transition; },
         () => { page.transition = before; },
+      );
+    },
+    setPageLayout: (layoutId, pageIndex) => {
+      const idx = pageIndex ?? curPageIndex();
+      const page = get().doc.pages[idx] as unknown as { layoutId?: string };
+      if (!page) return;
+      const before = page.layoutId;
+      if (before === layoutId) return;
+      perform(
+        () => { page.layoutId = layoutId; },
+        () => { page.layoutId = before; },
+      );
+    },
+    ensureSlideLayouts: () => {
+      const doc = get().doc as unknown as { masters?: unknown[]; layouts?: unknown[]; pages: { width: number; height: number }[] };
+      if (doc.layouts?.length) return; // already installed
+      const { master, layouts } = builtinMasterAndLayouts(doc.pages[0] ?? { width: 1920, height: 1080 });
+      const beforeM = doc.masters;
+      const beforeL = doc.layouts;
+      perform(
+        () => { doc.masters = [...(beforeM ?? []), master]; doc.layouts = layouts; },
+        () => { doc.masters = beforeM; doc.layouts = beforeL; },
+      );
+    },
+    setDeckTheme: (theme) => {
+      const doc = get().doc as unknown as { theme?: Theme; masters?: { theme?: string }[] };
+      const before = doc.theme;
+      const beforeMasters = doc.masters?.map((m) => m.theme);
+      if (before?.id === theme?.id) return;
+      perform(
+        () => {
+          // Reuse the pure helper so the file-level swap (and master repointing)
+          // stays in one place; then mirror it onto the live mutable doc.
+          if (!theme) { doc.theme = undefined; return; }
+          const next = applyTheme(get().doc, theme);
+          doc.theme = next.theme;
+          if (next.masters && doc.masters) next.masters.forEach((m, i) => { if (doc.masters![i]) doc.masters![i].theme = m.theme; });
+        },
+        () => {
+          doc.theme = before;
+          if (beforeMasters && doc.masters) doc.masters.forEach((m, i) => { m.theme = beforeMasters[i]; });
+        },
       );
     },
     setPageNotes: (notes, pageIndex) => {

--- a/packages/a11y/src/__tests__/slide-title.test.ts
+++ b/packages/a11y/src/__tests__/slide-title.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { createBlankDesign, type DesignFile } from "@hc/schema";
+import { checkAccessibility } from "../index";
+
+function deck(names: (string | undefined)[]): DesignFile {
+  const file = createBlankDesign({ title: "Deck", width: 800, height: 600 });
+  file.pages = names.map((name, i) => ({ ...structuredClone(file.pages[0]), id: `p${i}`, name }));
+  return file;
+}
+
+describe("slide-title check (doc 28 FR-3 / FR-29)", () => {
+  it("flags every untitled slide in a deck", () => {
+    const issues = checkAccessibility(deck(["Agenda", undefined, "   "])).filter((i) => i.kind === "slide-title");
+    expect(issues).toHaveLength(2);
+    expect(issues[0].pageIndex).toBe(1);
+    expect(issues[1].pageIndex).toBe(2);
+    expect(issues[0].severity).toBe("warning");
+  });
+
+  it("passes a fully titled deck", () => {
+    const issues = checkAccessibility(deck(["One", "Two"])).filter((i) => i.kind === "slide-title");
+    expect(issues).toHaveLength(0);
+  });
+
+  it("exempts a single-page design (not a deck)", () => {
+    const file = createBlankDesign({ title: "Poster", width: 800, height: 600 });
+    delete file.pages[0].name;
+    const issues = checkAccessibility(file).filter((i) => i.kind === "slide-title");
+    expect(issues).toHaveLength(0);
+  });
+
+  it("points at the page, so the UI navigates rather than selecting a node", () => {
+    const d = deck(["A", undefined]);
+    const issue = checkAccessibility(d).find((i) => i.kind === "slide-title")!;
+    expect(issue.nodeId).toBe(d.pages[1].id);
+  });
+});

--- a/packages/a11y/src/index.ts
+++ b/packages/a11y/src/index.ts
@@ -12,7 +12,7 @@ import { walkNodes, type Color, type DesignFile, type Fill } from "@hc/schema";
 import { contrastRatio } from "@hc/color";
 
 export type A11ySeverity = "error" | "warning";
-export type A11yKind = "contrast" | "alt-text" | "small-text" | "touch-target";
+export type A11yKind = "contrast" | "alt-text" | "small-text" | "touch-target" | "slide-title";
 
 export interface A11yIssue {
   nodeId: string;
@@ -51,6 +51,23 @@ function isLarge(fontSize: number, weight: number): boolean {
 /** Audit a design file. Returns one issue per problem, in page/visit order. */
 export function checkAccessibility(doc: DesignFile): A11yIssue[] {
   const issues: A11yIssue[] = [];
+  // Slide titles (doc 28 FR-3/FR-29): every slide in a deck needs a name, or a
+  // screen-reader user cannot navigate the presentation. Single-page designs
+  // are not decks, so they are exempt.
+  if (doc.pages.length > 1) {
+    doc.pages.forEach((page, pageIndex) => {
+      if (!page.name?.trim()) {
+        issues.push({
+          nodeId: page.id,
+          nodeName: page.name,
+          pageIndex,
+          kind: "slide-title",
+          severity: "warning",
+          message: `Slide ${pageIndex + 1} has no title. Name the slide so screen readers can navigate the deck.`,
+        });
+      }
+    });
+  }
   doc.pages.forEach((page, pageIndex) => {
     const bg = solidOf(page.background) ?? WHITE;
     walkNodes(
@@ -142,7 +159,7 @@ export interface A11ySummary {
 
 /** Roll up an issue list into counts for the accessibility panel/score. */
 export function summarizeAccessibility(issues: A11yIssue[]): A11ySummary {
-  const byKind: Record<A11yKind, number> = { contrast: 0, "alt-text": 0, "small-text": 0, "touch-target": 0 };
+  const byKind: Record<A11yKind, number> = { contrast: 0, "alt-text": 0, "small-text": 0, "touch-target": 0, "slide-title": 0 };
   let errors = 0;
   let warnings = 0;
   for (const i of issues) {


### PR DESCRIPTION
Surfaces the schema-v11 slide master/layout/theme model in the editor, and enforces the accessible slide titles the title placeholder exists to guarantee.

## What changed

- **Store**: `setPageLayout`, `ensureSlideLayouts` (installs the five built-in layouts as one undoable action, so a deck opts in explicitly), and `setDeckTheme`, which delegates the file-level swap to the pure `applyTheme` helper rather than duplicating the master-repointing rule.
- **Properties panel**: a Layout picker (opt-in prompt when a deck has none, a select once installed, tolerating a deleted layout) and a Deck theme swatch list with three built-in themes plus a clear action. Both state plainly that slide content is never restyled.
- **`@hc/a11y`**: a new `slide-title` check flags every untitled slide in a multi-page deck. Single-page designs are exempt. The issue points at a page rather than a node, so the dialog navigates to the slide instead of selecting nothing and zooming to an empty selection.

## Data safety

No schema, migration, or SQL change. This reads fields that already shipped in v11 (`masters`, `layouts`, `theme`, `Page.layoutId`), all optional; a deck carrying none of them behaves exactly as before.

## Verification

Nine browser assertions against the built binary: the opt-in prompt appears on a deck with no layouts, installing reveals the picker with all five built-ins, a layout assigns, a theme applies, both persist to the server as `schemaVersion: 11`, page content is untouched by the theme swap, and the accessibility dialog flags the untitled slide.

Package tests (including four new `slide-title` tests), tsc, and lint all pass. One type error that `vitest` could not catch (transpile-only) was found by the package build: `summarizeAccessibility`'s `Record<A11yKind, number>` needed the new key.

## Follow-ups (not in this PR)

Placeholder guides on the canvas, slide sections, and the grid/outline overview remain, per the F28 Phase 1 list.