### PR TITLE
Fix skewed Version-history timestamps by pinning the DB session to UTC

### DIFF
--- a/backend/internal/platform/db/db.go
+++ b/backend/internal/platform/db/db.go
@@ -12,9 +12,18 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// Connect parses the DSN (handling Prisma's `schema` query param), opens a pool,
-// and verifies connectivity with a ping.
-func Connect(ctx context.Context, raw string) (*pgxpool.Pool, error) {
+// buildConfig parses the DSN (handling Prisma's `schema` query param) into a
+// pool config, pinning the session search_path and timezone.
+//
+// timezone is pinned to UTC on every connection. The `created_at`/`updated_at`
+// columns are `timestamp without time zone`, and pgx reads such values back as a
+// UTC-labelled time.Time; the whole codebase serializes with `.UTC()`. For that
+// to be truthful, the value written by `CURRENT_TIMESTAMP`/`now()` defaults must
+// also be UTC wall-clock, which only holds when the session runs in UTC. Without
+// this, a server whose default timezone is not UTC stores local wall-clock and
+// every timestamp comes back skewed by the offset (e.g. a just-created version
+// showing "7h ago" in Version history).
+func buildConfig(raw string) (*pgxpool.Config, error) {
 	schema := "public"
 	if u, err := url.Parse(raw); err == nil {
 		q := u.Query()
@@ -34,6 +43,17 @@ func Connect(ctx context.Context, raw string) (*pgxpool.Pool, error) {
 		cfg.ConnConfig.RuntimeParams = map[string]string{}
 	}
 	cfg.ConnConfig.RuntimeParams["search_path"] = schema
+	cfg.ConnConfig.RuntimeParams["timezone"] = "UTC"
+	return cfg, nil
+}
+
+// Connect parses the DSN (handling Prisma's `schema` query param), opens a pool,
+// and verifies connectivity with a ping.
+func Connect(ctx context.Context, raw string) (*pgxpool.Pool, error) {
+	cfg, err := buildConfig(raw)
+	if err != nil {
+		return nil, err
+	}
 
 	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {

--- a/backend/internal/platform/db/db_test.go
+++ b/backend/internal/platform/db/db_test.go
@@ -1,0 +1,44 @@
+package db
+
+import "testing"
+
+// The session must run in UTC so CURRENT_TIMESTAMP/now() defaults on the naive
+// `timestamp without time zone` columns store UTC wall-clock, matching how pgx
+// reads them back (UTC-labelled) and how the code serializes (`.UTC()`).
+// Without this the Version-history timestamps skew by the server's offset.
+func TestBuildConfig_PinsUTCAndSchema(t *testing.T) {
+	cfg, err := buildConfig("postgres://u:p@localhost:5432/hycanvas?schema=tenant7")
+	if err != nil {
+		t.Fatalf("buildConfig: %v", err)
+	}
+	rp := cfg.ConnConfig.RuntimeParams
+	if rp["timezone"] != "UTC" {
+		t.Fatalf("timezone = %q, want UTC", rp["timezone"])
+	}
+	// Prisma's `schema` query param becomes the search_path (not a DSN param).
+	if rp["search_path"] != "tenant7" {
+		t.Fatalf("search_path = %q, want tenant7", rp["search_path"])
+	}
+}
+
+// With no `schema` param the search_path defaults to public, and UTC is still
+// pinned.
+func TestBuildConfig_DefaultSchema(t *testing.T) {
+	cfg, err := buildConfig("postgres://u:p@localhost:5432/hycanvas")
+	if err != nil {
+		t.Fatalf("buildConfig: %v", err)
+	}
+	rp := cfg.ConnConfig.RuntimeParams
+	if rp["search_path"] != "public" {
+		t.Fatalf("search_path = %q, want public", rp["search_path"])
+	}
+	if rp["timezone"] != "UTC" {
+		t.Fatalf("timezone = %q, want UTC", rp["timezone"])
+	}
+}
+
+func TestBuildConfig_InvalidDSN(t *testing.T) {
+	if _, err := buildConfig("://not a dsn"); err == nil {
+		t.Fatal("expected error for an invalid DSN")
+	}
+}


### PR DESCRIPTION
Closes #6.

## Problem
A just-created version shows a stale relative time in Version history (e.g. "7h ago" for a save that just happened).

## Root cause
`created_at` / `updated_at` are `timestamp without time zone`, defaulting to `CURRENT_TIMESTAMP`. pgx reads such columns back as a UTC-labelled `time.Time`, and the backend serializes everywhere with `.UTC().Format(...)`, so the intent is UTC end to end. But the pool pinned only `search_path`, not the session timezone. On a server whose default timezone is not UTC, `CURRENT_TIMESTAMP` writes local wall-clock; the client then reads that wall-clock as UTC, skewing every timestamp by the server's offset (a UTC-7 server yields exactly "7h ago").

This affected all naive timestamp columns (designs, snapshots, versions, comments, ...), not just version history.

## Fix
Pin `timezone=UTC` as a connection RuntimeParam alongside `search_path`, so default timestamps are UTC wall-clock and match how they are read and serialized. No schema change, no SQL migration, no stored data touched. The DSN-to-config logic is extracted into `buildConfig`, with unit tests asserting both `timezone` and `search_path`.

## Verification
- New unit tests pass; `go build` and `go vet` clean.
- Reproduced in Postgres: a row inserted under a UTC-7 session reads back as 25200s (7h) ago; the identical insert under a UTC-pinned session reads back as 0s ago ("just now").

## Note
This corrects all new writes. Rows already stored on an affected instance under a non-UTC session remain skewed in the DB; un-skewing them would require a destructive backfill by the old offset, deliberately left out.