### PR TITLE
Security: resolve CodeQL path-injection and request-forgery alerts

### DIFF
--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -68,11 +68,18 @@ func (l *Local) Kind() string { return "local" }
 // pathFor resolves a key to an absolute path, refusing anything that escapes the
 // base or is itself absolute (mirrors the Node driver's guard).
 func (l *Local) pathFor(key string) (string, error) {
+	// Validate against the shared key policy first: this rejects an empty,
+	// absolute, or '..'-containing key outright, before the value is ever used to
+	// build a filesystem path. Both drivers use the same allowlist.
+	if _, err := normalizeKey(key); err != nil {
+		return "", err
+	}
 	if filepath.IsAbs(key) {
 		return "", errors.New("storage key must be relative: " + key)
 	}
 	clean := strings.TrimLeft(filepath.Clean(key), string(filepath.Separator))
 	full := filepath.Join(l.base, clean)
+	// Defense in depth: the resolved path must still stay within the base dir.
 	if full != l.base && !strings.HasPrefix(full, l.base+string(filepath.Separator)) {
 		return "", errors.New("invalid storage key escapes base: " + key)
 	}

--- a/backend/internal/storage/storage_test.go
+++ b/backend/internal/storage/storage_test.go
@@ -1,0 +1,36 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// The Local driver must confine every key under its base directory: absolute,
+// empty, and '..'-traversal keys are rejected before any filesystem access,
+// while ordinary relative keys resolve to a path inside the base.
+func TestLocalPathFor(t *testing.T) {
+	base := t.TempDir()
+	l, err := NewLocal(base)
+	if err != nil {
+		t.Fatalf("NewLocal: %v", err)
+	}
+
+	bad := []string{"", "/absolute", "a/../../etc/passwd", "..", "../x", "x/../../../y", "/etc/passwd"}
+	for _, k := range bad {
+		if _, err := l.pathFor(k); err == nil {
+			t.Errorf("pathFor(%q) should error", k)
+		}
+	}
+
+	good := []string{"designs/a/snap.ocd", "assets/ws-1/uuid.png", "single", "a/b/c/d"}
+	for _, k := range good {
+		full, err := l.pathFor(k)
+		if err != nil {
+			t.Errorf("pathFor(%q) unexpected error: %v", k, err)
+			continue
+		}
+		if full != filepath.Join(l.base, k) {
+			t.Errorf("pathFor(%q) = %q; want %q", k, full, filepath.Join(l.base, k))
+		}
+	}
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1557,7 +1557,7 @@ export class HyCanvasClient {
   }
   /** The authenticated download URL for a completed video export (cookie auth). */
   videoExportDownloadUrl(designId: string, jobId: string): string {
-    return `${this.baseUrl}/v1/designs/${designId}/export/video/${jobId}/download`;
+    return `${this.baseUrl}/v1/designs/${encodeURIComponent(designId)}/export/video/${encodeURIComponent(jobId)}/download`;
   }
   /** Enqueue a DOCX or PDF render of a doc design. Poll via getJob,
    *  then download from docExportDownloadUrl. */
@@ -1566,14 +1566,14 @@ export class HyCanvasClient {
   }
   /** The authenticated download URL for a completed doc export (cookie auth). */
   docExportDownloadUrl(designId: string, jobId: string): string {
-    return `${this.baseUrl}/v1/designs/${designId}/export/doc/${jobId}/download`;
+    return `${this.baseUrl}/v1/designs/${encodeURIComponent(designId)}/export/doc/${encodeURIComponent(jobId)}/download`;
   }
   /** The authenticated URL for an accessibility-tagged PDF of the whole deck,
    *  rendered by the Go encoder (doc 28 FR-22). It serves the design as last
    *  saved, and its text is real text: selectable, searchable, and readable by
    *  assistive technology in the author's reading order. */
   taggedPdfUrl(designId: string): string {
-    return `${this.baseUrl}/v1/designs/${designId}/render.pdf?page=all`;
+    return `${this.baseUrl}/v1/designs/${encodeURIComponent(designId)}/render.pdf?page=all`;
   }
   /** Convert a whiteboard design into a presentation deck. Poll via
    *  getJob; the result carries the new design id to open. */


### PR DESCRIPTION
Resolves the open code-scanning alerts (#33, #34, #36, #37).

## go/path-injection — `backend/internal/storage/storage.go` (Get/Delete)
The Local driver already confined keys under its base, but via a custom prefix check CodeQL didn't recognize. `pathFor` now runs the shared `normalizeKey` allowlist first, which rejects empty, absolute, and any `..`-traversal key **before** the value is used to build a filesystem path. The base-containment check remains as defense in depth, and both storage drivers now share one key policy. Adds a `pathFor` test covering traversal and valid keys. Behavior is unchanged for real (opaque, content-addressed) keys.

## js/request-forgery — `frontend/src/components/editor/VideoSurface.tsx` (export downloads)
Both sites `fetch()` a URL from `videoExportDownloadUrl`, which interpolated `designId`/`jobId` (route-derived) raw into the path. The URL builders (`videoExportDownloadUrl`, `docExportDownloadUrl`, `taggedPdfUrl`) now `encodeURIComponent` those segments, so a value can't alter the URL structure or authority. These are same-origin, credentialed fetches to our own API; encoding is the correct hardening.

## Verification
- `go build`, `go vet`, and storage tests pass; new `TestLocalPathFor` covers the traversal cases.
- `@hc/sdk` builds clean; URL-builder signatures are unchanged, so no consumer changes.
- CodeQL re-runs on this PR; alerts should clear on the new analysis.