### PR TITLE
Security: bump protobufjs to >= 7.6.5 (Dependabot alert #6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,6 @@
       "version": "7.29.7",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -869,7 +868,6 @@
       "version": "8.60.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -1110,7 +1108,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1351,7 +1348,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1627,7 +1623,6 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1797,7 +1792,6 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -2951,7 +2945,6 @@
     "frontend/node_modules/react-dom": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3838,46 +3831,51 @@
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.1",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.1",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.1",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.61.1",
@@ -3938,7 +3936,6 @@
       "version": "19.2.16",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4699,7 +4696,8 @@
     },
     "node_modules/flatbuffers": {
       "version": "25.9.23",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -4827,7 +4825,8 @@
     },
     "node_modules/guid-typescript": {
       "version": "1.0.9",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -5261,7 +5260,8 @@
     },
     "node_modules/long": {
       "version": "5.3.2",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -5387,7 +5387,8 @@
     },
     "node_modules/onnxruntime-common": {
       "version": "1.21.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/onnxruntime-web": {
       "version": "1.21.0",
@@ -5500,7 +5501,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5510,7 +5510,8 @@
     },
     "node_modules/platform": {
       "version": "1.3.6",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pngjs": {
       "version": "5.0.0",
@@ -5563,9 +5564,12 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.3",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -5573,7 +5577,6 @@
         "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
@@ -5666,7 +5669,6 @@
     "node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6186,7 +6188,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6211,7 +6212,6 @@
       "version": "7.3.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -6554,7 +6554,6 @@
     "node_modules/yjs": {
       "version": "13.6.31",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"
       },
@@ -6570,7 +6569,6 @@
     "node_modules/zod": {
       "version": "4.4.3",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "vite": "^7.3.6",
     "esbuild": ">=0.28.1",
     "shell-quote": ">=1.8.4",
-    "postcss": ">=8.5.10"
+    "postcss": ">=8.5.10",
+    "protobufjs": ">=7.6.5"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
Resolves Dependabot alert #6 (GHSA-j3f2-48v5-ccww / CVE-2026-59877, medium).

**Issue:** protobufjs 7.5.0 to 7.6.4 has a denial of service via an infinite loop in `.proto` option parsing. It is pulled in transitively through `onnxruntime-web` (via `@imgly/background-removal`), and the committed `package-lock.json` pinned 7.6.3.

**Fix:** Add a `protobufjs: ">=7.6.5"` entry to the root `overrides` block (the same mechanism the repo already uses to force security bumps for dompurify, esbuild, shell-quote, and postcss) and update the lockfile to 7.6.5. `onnxruntime-web` requires `^7.2.4`, which 7.6.5 satisfies, so the bump is non-breaking and stays on the 7.x line.

Only `package.json` and `package-lock.json` change. No app code touched.