### PR TITLE
Security: patch shell-quote, js-yaml, brace-expansion (Dependabot #7-#10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -999,25 +999,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "frontend/node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "frontend/node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "frontend/node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "10.2.5",
       "dev": true,
@@ -1137,11 +1118,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
-    },
-    "frontend/node_modules/argparse": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "Python-2.0"
     },
     "frontend/node_modules/aria-query": {
       "version": "5.3.2",
@@ -1309,6 +1285,16 @@
         "node": ">= 0.4"
       }
     },
+    "frontend/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "frontend/node_modules/baseline-browser-mapping": {
       "version": "2.10.33",
       "license": "Apache-2.0",
@@ -1317,6 +1303,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "frontend/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "frontend/node_modules/braces": {
@@ -2411,27 +2410,6 @@
       "version": "4.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "frontend/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "frontend/node_modules/jsesc": {
       "version": "3.1.0",
@@ -4081,6 +4059,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "dev": true,
@@ -4132,7 +4117,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5205,6 +5192,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "dev": true,
@@ -5883,7 +5893,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "dompurify": ">=3.4.11",
     "vite": "^7.3.6",
     "esbuild": ">=0.28.1",
-    "shell-quote": ">=1.8.4",
+    "shell-quote": ">=1.9.0",
     "postcss": ">=8.5.10",
     "protobufjs": ">=7.6.5"
   },


### PR DESCRIPTION
Clears the four remaining open Dependabot alerts, all high-severity npm DoS issues in transitive dependencies. `npm audit` now reports 0 vulnerabilities.

| Alert | Package | Advisory | Change |
|---|---|---|---|
| #10 | shell-quote | GHSA-395f-4hp3-45gv (quadratic DoS in `parse()`) | override `>=1.8.4` was too loose (1.8.4 is vulnerable); tightened to `>=1.9.0`, resolves to 1.10.0 |
| #9 | js-yaml | GHSA-52cp-r559-cp3m (quadratic CPU via merge-key chains) | 4.2.0 to 4.3.0 (stays on 4.x) |
| #8 | brace-expansion | GHSA-3jxr-9vmj-r5cp (exponential `{}` expansion) | 1.1.15 to 1.1.16 |
| #7 | brace-expansion | GHSA-3jxr-9vmj-r5cp (same) | 5.0.6 to 5.0.7 |

brace-expansion sits at two major lines in the tree, so it was bumped with `npm update` (which respects each dependent's range) rather than a forced override that would wrongly pin both instances to one version.

Only `package.json` (the shell-quote override) and `package-lock.json` change. No app code touched.