### PR TITLE
Retry the initial DB connect on boot instead of failing once

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,14 @@ PORT=8005
 # migrations out of band (npm run db:migrate runs them explicitly).
 DB_AUTO_MIGRATE="true"
 
+# Tolerate a database that is still starting up when the API boots (common right
+# after a host reboot, when this process races Postgres). The initial connect is
+# retried DB_CONNECT_ATTEMPTS times, waiting DB_CONNECT_RETRY_DELAY between tries,
+# before giving up. Defaults (12 x 5s) cover a typical cold start; raise the
+# attempts for a database that replays a large WAL after an unclean shutdown.
+# DB_CONNECT_ATTEMPTS="12"
+# DB_CONNECT_RETRY_DELAY="5s"
+
 # Directory of the exported Next.js frontend for the binary to serve. The dist
 # bundle sets this to ./public; in dev the frontend runs separately (next dev),
 # so leave it blank to serve the API only.

--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ All configuration is read from the root `.env` (copy `.env.example`). The most i
 | `PORT` | both | Backend port (default `8005`). |
 | `NODE_ENV` | both | `development` or `production`. |
 | `DB_AUTO_MIGRATE` | both | When `true`, the server applies migrations on boot. |
+| `DB_CONNECT_ATTEMPTS` | both | Times to retry the initial DB connect before giving up (default `12`). Tolerates Postgres still starting after a host reboot. |
+| `DB_CONNECT_RETRY_DELAY` | both | Wait between initial-connect retries, as a Go duration (default `5s`). |
 | `NEXT_PUBLIC_BACKEND_URL` | dev | Frontend API base in dev (`http://localhost:8005/api`). Unused in the dist build (it calls same-origin `/api`). |
 | `FRONTEND_URL` | both | Allowed CORS origin for the API (dev: `http://localhost:3000`). |
 | `APP_URL` | prod | Public base URL used in generated links (verify-email, magic-link, share). |

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -133,9 +133,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	pool, err := db.Connect(context.Background(), cfg.DatabaseURL)
+	// Tolerate a database that is still starting up (e.g. right after a host
+	// reboot, when this process races Postgres): retry the initial connect on a
+	// fixed interval before giving up, instead of exiting on the first refusal.
+	pool, err := db.ConnectWithRetry(context.Background(), cfg.DatabaseURL, cfg.DBConnectAttempts, cfg.DBConnectRetryDelay,
+		func(attempt, remaining int, err error) {
+			logger.Warn("database not ready; will retry",
+				"attempt", attempt, "remaining", remaining, "retry_in", cfg.DBConnectRetryDelay.String(), "err", err)
+		})
 	if err != nil {
-		logger.Error("database connect failed", "err", err)
+		logger.Error("database connect failed", "attempts", cfg.DBConnectAttempts, "err", err)
 		os.Exit(1)
 	}
 	defer pool.Close()

--- a/backend/internal/platform/config/config.go
+++ b/backend/internal/platform/config/config.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/joho/godotenv"
 )
@@ -32,6 +33,14 @@ type Config struct {
 	PublicDir string
 	// AutoMigrate applies pending SQL migrations on boot (default true).
 	AutoMigrate bool
+	// DBConnectAttempts and DBConnectRetryDelay tolerate a database that is still
+	// starting up when the API boots, which is common right after a host reboot
+	// when the process races Postgres. The initial connect is retried up to
+	// DBConnectAttempts times, waiting DBConnectRetryDelay between tries, before
+	// the API gives up. Defaults (12 x 5s) cover a typical cold start; raise
+	// DB_CONNECT_ATTEMPTS for a database that replays a large WAL after a reboot.
+	DBConnectAttempts   int           // DB_CONNECT_ATTEMPTS (default 12)
+	DBConnectRetryDelay time.Duration // DB_CONNECT_RETRY_DELAY (default 5s)
 	// Auth gates which sign-in methods and account-creation paths are available.
 	Auth AuthPolicy
 	// Captcha optionally protects the human-facing auth forms.
@@ -84,6 +93,9 @@ func Load() (Config, error) {
 		AISecret:    os.Getenv("AI_SECRET"),
 		PublicDir:   getenv("PUBLIC_DIR", "./public"),
 		AutoMigrate: os.Getenv("DB_AUTO_MIGRATE") != "false",
+
+		DBConnectAttempts:   envInt("DB_CONNECT_ATTEMPTS", 12),
+		DBConnectRetryDelay: envDuration("DB_CONNECT_RETRY_DELAY", 5*time.Second),
 		Auth: AuthPolicy{
 			PasswordLogin:   envBool("AUTH_PASSWORD_LOGIN_ENABLED", true),
 			PasswordSignup:  envBool("AUTH_PASSWORD_SIGNUP_ENABLED", true),
@@ -112,6 +124,28 @@ func envFloat(key string, def float64) float64 {
 	if v := os.Getenv(key); v != "" {
 		if f, err := strconv.ParseFloat(v, 64); err == nil {
 			return f
+		}
+	}
+	return def
+}
+
+// envInt reads an integer env var, keeping the default on empty or unparseable
+// input so a typo never silently changes the value.
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+// envDuration reads a Go duration env var (e.g. "5s", "500ms", "2m"), keeping the
+// default on empty or unparseable input.
+func envDuration(key string, def time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(strings.TrimSpace(v)); err == nil {
+			return d
 		}
 	}
 	return def

--- a/backend/internal/platform/db/db.go
+++ b/backend/internal/platform/db/db.go
@@ -68,3 +68,36 @@ func Connect(ctx context.Context, raw string) (*pgxpool.Pool, error) {
 	}
 	return pool, nil
 }
+
+// ConnectWithRetry opens the pool like Connect, but tolerates a database that is
+// still coming up when the app boots, which is common right after a host reboot
+// when the process races Postgres. It retries a failed connect up to `attempts`
+// times, waiting `delay` between tries, and returns the first pool that connects
+// or the last error. attempts < 1 is treated as a single try (no retry). When
+// set, onRetry is called before each wait (with the attempt just made and how
+// many remain) so the caller can log progress. A cancelled ctx aborts the wait.
+func ConnectWithRetry(ctx context.Context, raw string, attempts int, delay time.Duration, onRetry func(attempt, remaining int, err error)) (*pgxpool.Pool, error) {
+	if attempts < 1 {
+		attempts = 1
+	}
+	var lastErr error
+	for i := 1; i <= attempts; i++ {
+		pool, err := Connect(ctx, raw)
+		if err == nil {
+			return pool, nil
+		}
+		lastErr = err
+		if i == attempts {
+			break
+		}
+		if onRetry != nil {
+			onRetry(i, attempts-i, err)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+	return nil, lastErr
+}

--- a/backend/internal/platform/db/db_test.go
+++ b/backend/internal/platform/db/db_test.go
@@ -1,6 +1,61 @@
 package db
 
-import "testing"
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// A refused local port fails each connect attempt fast, so the retry loop can be
+// exercised without a real database.
+const refusedDSN = "postgres://u:p@127.0.0.1:1/db"
+
+// ConnectWithRetry retries attempts-1 times (waiting between tries) before it
+// gives up, and reports progress through onRetry.
+func TestConnectWithRetry_RetriesThenFails(t *testing.T) {
+	retries := 0
+	start := time.Now()
+	pool, err := ConnectWithRetry(context.Background(), refusedDSN, 3, 20*time.Millisecond,
+		func(attempt, remaining int, err error) { retries++ })
+	if pool != nil {
+		pool.Close()
+	}
+	if err == nil {
+		t.Fatal("expected an error connecting to a refused port")
+	}
+	if retries != 2 {
+		t.Fatalf("onRetry called %d times, want 2 (attempts-1)", retries)
+	}
+	if elapsed := time.Since(start); elapsed < 40*time.Millisecond {
+		t.Fatalf("did not wait between retries (elapsed %s)", elapsed)
+	}
+}
+
+// A non-positive attempts count means a single try, with no retry callback.
+func TestConnectWithRetry_SingleTry(t *testing.T) {
+	retries := 0
+	if _, err := ConnectWithRetry(context.Background(), refusedDSN, 0, time.Second,
+		func(int, int, error) { retries++ }); err == nil {
+		t.Fatal("expected an error")
+	}
+	if retries != 0 {
+		t.Fatalf("onRetry called %d times, want 0 for a single try", retries)
+	}
+}
+
+// A cancelled context aborts the wait between retries promptly rather than
+// sleeping the full delay.
+func TestConnectWithRetry_CancelledContextAbortsWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	if _, err := ConnectWithRetry(ctx, refusedDSN, 5, time.Hour, nil); err == nil {
+		t.Fatal("expected an error")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("cancelled context did not abort the long wait (elapsed %s)", elapsed)
+	}
+}
 
 // The session must run in UTC so CURRENT_TIMESTAMP/now() defaults on the naive
 // `timestamp without time zone` columns store UTC wall-clock, matching how pgx


### PR DESCRIPTION
Fixes #15.

## Problem
On startup the API connects to Postgres once and exits on the first failure. After a host reboot the process often comes up before Postgres is ready, so `hycanvas service start` fails with `connection refused` even though the database becomes available a few seconds later.

## Fix
Add `db.ConnectWithRetry`, which retries a failed initial connect on a fixed interval before giving up, and use it from the `cmd/api` boot path. Each retry is logged (`database not ready; will retry`).

Configurable, with sensible defaults:
- `DB_CONNECT_ATTEMPTS` (default `12`)
- `DB_CONNECT_RETRY_DELAY` (default `5s`)

So out of the box it tolerates ~60s of cold start. `cmd/migrate` and the setup wizard's connectivity test keep the single-shot `db.Connect` (correct for a manual migration and a "test this DSN" check).

## Notes
- Pure code change: no schema, no SQL migration.
- Unit tests cover the retry count (attempts-1 waits), the single-try case when attempts is non-positive, and a cancelled context aborting the wait.
- Docs updated: `.env.example` and the README env table.