### PR TITLE
Say what was unreachable when the DB connect fails

### DIFF
--- a/backend/internal/platform/db/db.go
+++ b/backend/internal/platform/db/db.go
@@ -6,11 +6,18 @@ package db
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// pingTimeout bounds the connectivity check on the initial connect.
+const pingTimeout = 5 * time.Second
 
 // buildConfig parses the DSN (handling Prisma's `schema` query param) into a
 // pool config, pinning the session search_path and timezone.
@@ -60,13 +67,29 @@ func Connect(ctx context.Context, raw string) (*pgxpool.Pool, error) {
 		return nil, err
 	}
 
-	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	pingCtx, cancel := context.WithTimeout(ctx, pingTimeout)
 	defer cancel()
 	if err := pool.Ping(pingCtx); err != nil {
 		pool.Close()
-		return nil, err
+		return nil, pingErr(cfg, err)
 	}
 	return pool, nil
+}
+
+// pingErr annotates a failed connectivity check with the address that was tried,
+// never the credentials. pgx reports a refused port or an unresolvable host with
+// a descriptive error, but when packets are silently dropped (a firewall, or two
+// containers that share no route) the ping just hits its deadline and pgx returns
+// a bare "context deadline exceeded", which tells an operator nothing about what
+// was unreachable or why.
+func pingErr(cfg *pgxpool.Config, err error) error {
+	addr := net.JoinHostPort(cfg.ConnConfig.Host, strconv.Itoa(int(cfg.ConnConfig.Port)))
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("timed out after %s connecting to postgres at %s: %w "+
+			"(the address did not refuse the connection, it never answered: check that the database is reachable from here "+
+			"and that no firewall or container network is dropping the traffic)", pingTimeout, addr, err)
+	}
+	return fmt.Errorf("connecting to postgres at %s: %w", addr, err)
 }
 
 // ConnectWithRetry opens the pool like Connect, but tolerates a database that is

--- a/backend/internal/platform/db/db_test.go
+++ b/backend/internal/platform/db/db_test.go
@@ -2,6 +2,8 @@ package db
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -9,6 +11,35 @@ import (
 // A refused local port fails each connect attempt fast, so the retry loop can be
 // exercised without a real database.
 const refusedDSN = "postgres://u:p@127.0.0.1:1/db"
+
+// A connect failure must name the address that was tried so an operator can act
+// on it, and must never expose the credentials from the DSN.
+func TestPingErr_NamesAddressWithoutCredentials(t *testing.T) {
+	cfg, err := buildConfig("postgres://myuser:SuperSecret123@db.internal:5432/hycanvas")
+	if err != nil {
+		t.Fatalf("buildConfig: %v", err)
+	}
+
+	// A dropped-packet timeout is reported by pgx as a bare "context deadline
+	// exceeded"; it must be turned into something that says what was unreachable.
+	timeout := pingErr(cfg, context.DeadlineExceeded).Error()
+	for _, want := range []string{"db.internal:5432", "timed out", "firewall"} {
+		if !strings.Contains(timeout, want) {
+			t.Errorf("timeout error missing %q: %s", want, timeout)
+		}
+	}
+
+	generic := pingErr(cfg, errors.New("boom")).Error()
+	if !strings.Contains(generic, "db.internal:5432") {
+		t.Errorf("generic error missing address: %s", generic)
+	}
+
+	for _, msg := range []string{timeout, generic} {
+		if strings.Contains(msg, "SuperSecret123") {
+			t.Errorf("error leaked the DSN password: %s", msg)
+		}
+	}
+}
 
 // ConnectWithRetry retries attempts-1 times (waiting between tries) before it
 // gives up, and reports progress through onRetry.


### PR DESCRIPTION
Raised by #17, where a self-hoster's containers could not reach each other and the only output was:

```
{"level":"ERROR","msg":"database connect failed","err":"context deadline exceeded"}
```

That names neither the address tried nor the reason.

## Why the message was uninformative
pgx reports two of the three failure modes well, but not the third:

| Failure mode | Timing | Error today |
|---|---|---|
| Port refused | instant | descriptive, names the address |
| Host unresolvable | instant | descriptive, names the address |
| **Packets dropped** (firewall / no shared route) | **exactly 5s** | **bare `context deadline exceeded`** |

The ping simply hits its deadline, so pgx has nothing to report.

## Change
Annotate a failed connectivity check with the `host:port` that was tried, and for the timeout case add the distinction that actually helps: the address did not refuse the connection, it never answered, so look at reachability and firewalls rather than at Postgres itself.

Before:
```
context deadline exceeded
```
After:
```
timed out after 5s connecting to postgres at db.internal:5432: context deadline exceeded
(the address did not refuse the connection, it never answered: check that the database is
reachable from here and that no firewall or container network is dropping the traffic)
```

## Safety
Credentials are never included: the address is read from the parsed pool config rather than the DSN string, and a test asserts the DSN password never reaches the error text (verified across all three failure modes).

Pure code change: no schema, no SQL migration.