### PR TITLE
fix: enable OpenRouter image generation + zh-HK locale + timeout bump

### DIFF
--- a/backend/internal/ai/provider.go
+++ b/backend/internal/ai/provider.go
@@ -30,6 +30,7 @@ const (
 	ProviderDeepSeek    Provider = "deepseek"
 	ProviderZhipu       Provider = "zhipu"
 	ProviderAzureOpenAI Provider = "azure-openai"
+	ProviderOpenRouter  Provider = "openrouter"
 	ProviderCustom      Provider = "custom"
 )
 
@@ -282,7 +283,11 @@ func parseTextResponse(provider Provider, raw []byte) string {
 
 func buildImageRequest(cfg CallConfig, prompt, size string) httpRequest {
 	model := orDefault(cfg.ImageModel, "gpt-image-1")
-	u, headers := openAICompatEndpoint(cfg, model, "images/generations")
+	op := "images/generations"
+	if cfg.Provider == ProviderOpenRouter {
+		op = "images"
+	}
+	u, headers := openAICompatEndpoint(cfg, model, op)
 	return httpRequest{
 		url:     u,
 		headers: headers,
@@ -390,7 +395,7 @@ func isNegotiable4xx(err error) bool {
 // this is a privilege boundary and not merely a footgun.
 func newHTTPClient(allowLocalHTTP bool) *http.Client {
 	return &http.Client{
-		Timeout: 60 * time.Second,
+		Timeout: 120 * time.Second,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 5 {
 				return errors.New("too many redirects")

--- a/backend/internal/ai/registry.go
+++ b/backend/internal/ai/registry.go
@@ -52,7 +52,7 @@ var PRESETS = []ProviderPreset{
 	{ID: "mistral", Label: "Mistral", BaseURL: "https://api.mistral.ai/v1", DefaultModel: "mistral-large-latest", Capabilities: Capabilities{Text: true}},
 	{ID: "groq", Label: "Groq", BaseURL: "https://api.groq.com/openai/v1", DefaultModel: "llama-3.3-70b-versatile", Capabilities: Capabilities{Text: true}},
 	{ID: "together", Label: "Together AI", BaseURL: "https://api.together.xyz/v1", DefaultModel: "meta-llama/Llama-3.3-70B-Instruct-Turbo", DefaultImageModel: "black-forest-labs/FLUX.1-schnell", Capabilities: Capabilities{Text: true, Image: true}},
-	{ID: "openrouter", Label: "OpenRouter", BaseURL: "https://openrouter.ai/api/v1", DefaultModel: "openai/gpt-4o-mini", Capabilities: Capabilities{Text: true}},
+	{ID: "openrouter", Label: "OpenRouter", BaseURL: "https://openrouter.ai/api/v1", DefaultModel: "openai/gpt-4o-mini", DefaultImageModel: "openai/dall-e-3", Capabilities: Capabilities{Text: true, Image: true, DescribeImage: true}},
 	// EditImage is off: images/edits does not exist at the GA api-version the
 	// transport pins (2024-06-01), and the default dall-e-3 deployment cannot
 	// edit; advertising it would fail every call.

--- a/frontend/src/components/editor/AccessibilityDialog.tsx
+++ b/frontend/src/components/editor/AccessibilityDialog.tsx
@@ -28,6 +28,8 @@ const docLanguages = (): { value: string; label: string }[] => [
   { value: "hi-IN", label: "हिन्दी" },
   { value: "ja-JP", label: "日本語" },
   { value: "zh-CN", label: "中文 (简体)" },
+  { value: "zh-HK", label: "繁體中文（香港）" },
+  { value: "zh-TW", label: "繁體中文（台灣）" },
   { value: "ar-SA", label: "العربية" },
   { value: "he-IL", label: "עברית" },
 ];

--- a/frontend/src/components/settings/SettingsApp.tsx
+++ b/frontend/src/components/settings/SettingsApp.tsx
@@ -50,6 +50,8 @@ const locales = (): { value: string; label: string }[] => [
   { value: "hi-IN", label: "हिन्दी" },
   { value: "ja-JP", label: "日本語" },
   { value: "zh-CN", label: "中文 (简体)" },
+  { value: "zh-HK", label: "繁體中文（香港）" },
+  { value: "zh-TW", label: "繁體中文（台灣）" },
 ];
 
 // Clock and week-start preferences. "auto" defers to the chosen language.


### PR DESCRIPTION
## Summary

OpenRouter supports image generation via its `/api/v1/images` endpoint, but HyCanvas currently marks it as text-only and routes image requests to `/images/generations` (which OpenRouter doesn't implement).

Changes validated on a self-hosted instance with qwen/qwen-image-3-pro.

## Changes

1. **registry.go** — OpenRouter preset: `Capabilities{Text: true}` → `Capabilities{Text: true, Image: true, DescribeImage: true}` + `DefaultImageModel: "openai/dall-e-3"`
2. **provider.go** — Added `ProviderOpenRouter` constant; `buildImageRequest()` uses `/images` (not `/images/generations`) for OpenRouter  
3. **provider.go** — Raised `newHTTPClient()` timeout from 60s → 120s (many image models exceed 60s)
4. **SettingsApp.tsx, AccessibilityDialog.tsx** — Added zh-HK (繁體中文（香港）) and zh-TW (繁體中文（台灣）) to language dropdowns (overlay locale files already work via LOCALES_DIR)