### PR TITLE
Report a failed sign-in database query as 500, not 401

### DIFF
--- a/backend/internal/accounts/accounts.go
+++ b/backend/internal/accounts/accounts.go
@@ -461,6 +461,14 @@ func (s *Service) UpdateProfile(ctx context.Context, userID string, in UpdatePro
 // client redeems via VerifyMfaLogin; no session is issued in that case.
 func (s *Service) Login(ctx context.Context, email, password, device, ip string) (*AuthUser, *Tokens, string, error) {
 	u, err := s.findUserByEmail(ctx, email)
+	// An unknown email and a wrong password must stay indistinguishable, so both
+	// answer ErrInvalidCredentials. An infrastructure failure is a different
+	// thing entirely: reporting an unreachable database as "invalid credentials"
+	// sends the operator hunting for a bad password while the real fault stays
+	// invisible to monitoring (a 401 pages nobody).
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil, "", err
+	}
 	if err != nil || u == nil || u.PasswordHash == nil {
 		return nil, nil, "", ErrInvalidCredentials
 	}

--- a/backend/internal/accounts/login_dberror_test.go
+++ b/backend/internal/accounts/login_dberror_test.go
@@ -1,0 +1,60 @@
+package accounts
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// errRow fails every Scan with a fixed error, standing in for a database that is
+// unreachable (the query times out rather than answering).
+type errRow struct{ err error }
+
+func (r errRow) Scan(...any) error { return r.err }
+
+// errDB is a DBTX whose every read fails, so Login exercises its error path with
+// no database present.
+type errDB struct{ err error }
+
+func (d errDB) QueryRow(context.Context, string, ...any) pgx.Row { return errRow{d.err} }
+func (d errDB) Query(context.Context, string, ...any) (pgx.Rows, error) {
+	return nil, d.err
+}
+func (d errDB) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, d.err
+}
+func (d errDB) Begin(context.Context) (pgx.Tx, error) { return nil, d.err }
+
+// A database failure during sign-in is not a credential problem. Reporting it as
+// ErrInvalidCredentials (a 401) tells the user their password is wrong and hides
+// the outage from anything watching 5xx, which is what made a self-hoster chase
+// a "wrong password" while their database was unreachable (issue #17).
+func TestLogin_DatabaseErrorIsNotInvalidCredentials(t *testing.T) {
+	dbErr := context.DeadlineExceeded
+	svc := NewService(errDB{err: dbErr}, "test-jwt-secret")
+
+	_, _, _, err := svc.Login(context.Background(), "someone@example.com", "password123", "dev", "127.0.0.1")
+	if err == nil {
+		t.Fatal("expected an error when the database is unreachable")
+	}
+	if errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("database failure reported as invalid credentials: %v", err)
+	}
+	if !errors.Is(err, dbErr) {
+		t.Fatalf("underlying database error not surfaced: %v", err)
+	}
+}
+
+// An unknown account must still be indistinguishable from a wrong password, so
+// pgx.ErrNoRows keeps answering ErrInvalidCredentials (no account enumeration).
+func TestLogin_UnknownUserStaysInvalidCredentials(t *testing.T) {
+	svc := NewService(errDB{err: pgx.ErrNoRows}, "test-jwt-secret")
+
+	_, _, _, err := svc.Login(context.Background(), "nobody@example.com", "password123", "dev", "127.0.0.1")
+	if !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("unknown user should be ErrInvalidCredentials, got: %v", err)
+	}
+}

--- a/backend/internal/httpapi/auth.go
+++ b/backend/internal/httpapi/auth.go
@@ -199,6 +199,13 @@ func loginHandler(svc *accounts.Service, secure bool) http.HandlerFunc {
 				writeJSON(w, http.StatusOK, map[string]any{"mfaRequired": true, "mfaToken": mfaToken})
 				return
 			}
+			if !errors.Is(err, accounts.ErrInvalidCredentials) {
+				// The credentials were never the problem (e.g. the database is
+				// unreachable). Answering 401 here tells the user their password
+				// is wrong and hides an outage from anything watching 5xx.
+				problemWithCode(w, r, http.StatusInternalServerError, "Internal Server Error", "sign-in is temporarily unavailable", "internal_error")
+				return
+			}
 			problemWithCode(w, r, http.StatusUnauthorized, "Unauthorized", "invalid email or password", "invalid_email_or_password")
 			return
 		}

--- a/frontend/public/locales/de.json
+++ b/frontend/public/locales/de.json
@@ -2965,6 +2965,7 @@
   "errors.api_image_provider_incapable": "Dieser Anbieter kann keine Bilder erzeugen. Wähle einen, der das kann, etwa OpenAI oder Together AI.",
   "errors.api_image_provider_key_required": "Der Bildanbieter braucht einen eigenen API-Schlüssel. Gib ihn ein und speichere erneut.",
   "errors.api_import_too_large": "Diese Datei ist zum Importieren zu groß.",
+  "errors.api_internal_error": "Auf unserer Seite ist etwas schiefgelaufen. Bitte versuche es gleich noch einmal.",
   "errors.api_invalid_api_key": "Dieser API-Schlüssel ist ungültig oder wurde widerrufen.",
   "errors.api_invalid_authentication_code": "Dieser Authentifizierungscode ist ungültig.",
   "errors.api_invalid_body": "Diese Anfrage konnte nicht verarbeitet werden. Bitte versuche es erneut.",

--- a/frontend/public/locales/es.json
+++ b/frontend/public/locales/es.json
@@ -2965,6 +2965,7 @@
   "errors.api_image_provider_incapable": "Ese proveedor no puede generar imágenes. Elige uno que sí pueda, como OpenAI o Together AI.",
   "errors.api_image_provider_key_required": "El proveedor de imágenes necesita su propia clave de API. Introdúcela y guarda de nuevo.",
   "errors.api_import_too_large": "Este archivo es demasiado grande para importarlo.",
+  "errors.api_internal_error": "Algo salió mal por nuestra parte. Inténtalo de nuevo en un momento.",
   "errors.api_invalid_api_key": "Esta clave de API no es válida o fue revocada.",
   "errors.api_invalid_authentication_code": "Ese código de autenticación no es válido.",
   "errors.api_invalid_body": "No se pudo procesar la solicitud. Inténtalo de nuevo.",

--- a/frontend/public/locales/fr.json
+++ b/frontend/public/locales/fr.json
@@ -2965,6 +2965,7 @@
   "errors.api_image_provider_incapable": "Ce fournisseur ne peut pas générer d'images. Choisissez-en un qui le peut, comme OpenAI ou Together AI.",
   "errors.api_image_provider_key_required": "Le fournisseur d'images a besoin de sa propre clé API. Saisissez-la et enregistrez à nouveau.",
   "errors.api_import_too_large": "Ce fichier est trop volumineux pour être importé.",
+  "errors.api_internal_error": "Un problème est survenu de notre côté. Veuillez réessayer dans un instant.",
   "errors.api_invalid_api_key": "Cette clé d'API est invalide ou a été révoquée.",
   "errors.api_invalid_authentication_code": "Ce code d'authentification n'est pas valide.",
   "errors.api_invalid_body": "Cette requête n'a pas pu être traitée. Veuillez réessayer.",

--- a/frontend/public/locales/hi.json
+++ b/frontend/public/locales/hi.json
@@ -2965,6 +2965,7 @@
   "errors.api_image_provider_incapable": "वह प्रोवाइडर इमेज जनरेट नहीं कर सकता। ऐसा प्रोवाइडर चुनें जो कर सके, जैसे OpenAI या Together AI।",
   "errors.api_image_provider_key_required": "इमेज प्रोवाइडर के लिए उसकी अपनी API कुंजी चाहिए। इसे दर्ज करें और दोबारा सेव करें।",
   "errors.api_import_too_large": "यह फ़ाइल आयात के लिए बहुत बड़ी है।",
+  "errors.api_internal_error": "हमारी ओर से कुछ गलत हो गया। कृपया कुछ देर बाद पुनः प्रयास करें।",
   "errors.api_invalid_api_key": "यह API कुंजी अमान्य है या रद्द कर दी गई है।",
   "errors.api_invalid_authentication_code": "वह प्रमाणीकरण कोड मान्य नहीं है।",
   "errors.api_invalid_body": "यह अनुरोध संसाधित नहीं हो सका। कृपया पुनः प्रयास करें।",

--- a/frontend/public/locales/ja.json
+++ b/frontend/public/locales/ja.json
@@ -2965,6 +2965,7 @@
   "errors.api_image_provider_incapable": "そのプロバイダーは画像を生成できません。OpenAI や Together AI など、生成できるものを選んでください。",
   "errors.api_image_provider_key_required": "画像プロバイダーには専用の API キーが必要です。入力してもう一度保存してください。",
   "errors.api_import_too_large": "このファイルは大きすぎてインポートできません。",
+  "errors.api_internal_error": "サーバー側で問題が発生しました。しばらくしてからもう一度お試しください。",
   "errors.api_invalid_api_key": "このAPIキーは無効か失効しています。",
   "errors.api_invalid_authentication_code": "その認証コードは無効です。",
   "errors.api_invalid_body": "このリクエストを処理できませんでした。もう一度お試しください。",

--- a/frontend/public/locales/pt-br.json
+++ b/frontend/public/locales/pt-br.json
@@ -2965,6 +2965,7 @@
   "errors.api_image_provider_incapable": "Esse provedor não gera imagens. Escolha um que gere, como OpenAI ou Together AI.",
   "errors.api_image_provider_key_required": "O provedor de imagens precisa da própria chave de API. Informe-a e salve de novo.",
   "errors.api_import_too_large": "Este arquivo é grande demais para importar.",
+  "errors.api_internal_error": "Algo deu errado do nosso lado. Tente novamente em instantes.",
   "errors.api_invalid_api_key": "Esta chave de API é inválida ou foi revogada.",
   "errors.api_invalid_authentication_code": "Esse código de autenticação não é válido.",
   "errors.api_invalid_body": "Não foi possível processar a solicitação. Tente novamente.",

--- a/frontend/public/locales/zh-cn.json
+++ b/frontend/public/locales/zh-cn.json
@@ -2965,6 +2965,7 @@
   "errors.api_image_provider_incapable": "该服务商无法生成图像。请选择可以生成的，例如 OpenAI 或 Together AI。",
   "errors.api_image_provider_key_required": "图像服务商需要它自己的 API 密钥。请填写后重新保存。",
   "errors.api_import_too_large": "此文件过大，无法导入。",
+  "errors.api_internal_error": "我们这边出了点问题，请稍后重试。",
   "errors.api_invalid_api_key": "此 API 密钥无效或已被吊销。",
   "errors.api_invalid_authentication_code": "该验证码无效。",
   "errors.api_invalid_body": "无法处理该请求，请重试。",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -2965,6 +2965,7 @@
   "errors.api_image_provider_incapable": "That provider cannot generate images. Choose one that can, such as OpenAI or Together AI.",
   "errors.api_image_provider_key_required": "The image provider needs its own API key. Enter it and save again.",
   "errors.api_import_too_large": "This file is too large to import.",
+  "errors.api_internal_error": "Something went wrong on our end. Please try again in a moment.",
   "errors.api_invalid_api_key": "This API key is invalid or has been revoked.",
   "errors.api_invalid_authentication_code": "That authentication code is not valid.",
   "errors.api_invalid_body": "That request could not be processed. Please try again.",


### PR DESCRIPTION
Surfaced by #17, where a self-hoster's database was unreachable and the app answered:

```
POST /api/v1/auth/signup -> 500 -> 120008 ms
POST /api/v1/auth/login  -> 401 -> 120005 ms
```

Signup was honest. Login was not: it reported a database timeout as **invalid credentials**, so the operator was told their password was wrong while the actual fault was that the query never reached Postgres.

## Cause
Two layers conflated an infrastructure failure with an authentication failure:

1. `accounts.Login` treated *every* `findUserByEmail` error as `ErrInvalidCredentials`. Because pgx reports a missing row as `pgx.ErrNoRows`, that branch had to catch errors, and a connection timeout fell into it too.
2. `loginHandler` mapped every non-MFA error to 401.

Beyond the confusing message, this hides outages: a 401 pages nobody, so monitoring watching 5xx never sees the database go down.

## Change
Distinguish "no such account" from "the query failed":

- `pgx.ErrNoRows` still answers `ErrInvalidCredentials`, so an unknown email and a wrong password stay indistinguishable and **account enumeration remains impossible**.
- Any other error propagates, and the handler answers 500.

## Tests
A stub `DBTX` injects failures, so no database is needed:
- a timed-out query is no longer reported as invalid credentials, and the underlying error is preserved
- an unknown user still returns `ErrInvalidCredentials`

Full backend suite passes. Pure code change: no schema, no SQL migration.