### PR TITLE
Bound the search result allocation by a constant

### DIFF
--- a/backend/internal/ai/search.go
+++ b/backend/internal/ai/search.go
@@ -233,7 +233,12 @@ func cleanResults(in []SearchResult, max int) []SearchResult {
 	if max > maxSearchResults {
 		max = maxSearchResults
 	}
-	out := make([]SearchResult, 0, max)
+	// Capacity is the CONSTANT bound rather than `max`. The clamps above already
+	// hold max in [0, maxSearchResults], so this reserves the same order of
+	// memory, but it keeps a request-derived value out of make() altogether:
+	// the allocation is bounded by construction, not by reasoning about the
+	// guards above it. `max` still caps the result count, in the loop below.
+	out := make([]SearchResult, 0, maxSearchResults)
 	for _, r := range in {
 		// Checked BEFORE appending. The check used to sit after, so a cap of
 		// zero still yielded one result: the break only fired once the list had


### PR DESCRIPTION
Resolves code-scanning alert 53 (`go/uncontrolled-allocation-size`, high) on `backend/internal/ai/search.go:236`.

## Assessment
The allocation was already safe. Immediately above it, `cleanResults` clamps `max` into `[0, maxSearchResults]` (10), and `Search` clamps again before calling. `TestCleanResultsClampsItsOwnAllocation` already covers `1<<40`, `-1`, `0` and `3`. So the alert is a false positive in the sense that no oversized allocation was reachable.

## Why change the code rather than dismiss it
The scanner cannot see the bound because the guards reassign the same variable before `make()`. Reserving the constant is the same order of memory (`max` can never exceed it), removes a request-derived value from `make()` altogether, and makes the bound hold by construction instead of by reasoning about the lines above it.

The clamp stays, it still caps the result count in the loop.

No behavior change; the existing tests pass unchanged. Pure code change: no schema, no SQL.