### PR TITLE
Keep id generation working on an insecure origin

### DIFF
--- a/frontend/src/lib/randomUuidPolyfill.test.ts
+++ b/frontend/src/lib/randomUuidPolyfill.test.ts
@@ -1,0 +1,51 @@
+// An instance served over plain HTTP at a LAN address (the common self-host
+// shape: a NAS at http://192.168.1.10:8005) is not a secure context, so the
+// browser withholds crypto.randomUUID and every id-minting action throws.
+import { describe, expect, it, afterEach } from "vitest";
+import { installRandomUuidPolyfill } from "./randomUuidPolyfill";
+
+const real = globalThis.crypto;
+const V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function setCrypto(c: unknown) {
+  Object.defineProperty(globalThis, "crypto", { value: c, configurable: true, writable: true });
+}
+
+afterEach(() => setCrypto(real));
+
+describe("crypto.randomUUID polyfill", () => {
+  it("supplies randomUUID when the origin is insecure", () => {
+    // What Chrome exposes on http://<lan-ip>: getRandomValues, but no randomUUID.
+    setCrypto({ getRandomValues: (a: Uint8Array) => real.getRandomValues(a) });
+    expect((globalThis.crypto as Crypto).randomUUID).toBeUndefined();
+
+    installRandomUuidPolyfill();
+
+    const id = (globalThis.crypto as Crypto).randomUUID();
+    expect(id).toMatch(V4);
+  });
+
+  it("produces distinct ids", () => {
+    setCrypto({ getRandomValues: (a: Uint8Array) => real.getRandomValues(a) });
+    installRandomUuidPolyfill();
+    const uuid = () => (globalThis.crypto as Crypto).randomUUID();
+    const ids = new Set(Array.from({ length: 500 }, uuid));
+    expect(ids.size).toBe(500);
+  });
+
+  it("leaves a native implementation untouched", () => {
+    const native = () => "11111111-2222-4333-8444-555555555555" as const;
+    setCrypto({ randomUUID: native, getRandomValues: (a: Uint8Array) => real.getRandomValues(a) });
+
+    installRandomUuidPolyfill();
+
+    expect((globalThis.crypto as Crypto).randomUUID).toBe(native);
+  });
+
+  it("does not invent randomness when getRandomValues is missing too", () => {
+    // Guessable ids would be worse than a loud failure, so nothing is installed.
+    setCrypto({});
+    installRandomUuidPolyfill();
+    expect((globalThis.crypto as Crypto).randomUUID).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/randomUuidPolyfill.ts
+++ b/frontend/src/lib/randomUuidPolyfill.ts
@@ -19,12 +19,12 @@ function uuidV4FromRandomValues(getRandomValues: (a: Uint8Array) => Uint8Array):
   const b = getRandomValues(new Uint8Array(16));
   b[6] = (b[6] & 0x0f) | 0x40; // version 4
   b[8] = (b[8] & 0x3f) | 0x80; // variant 10xx
-  const hex: string[] = [];
-  for (let i = 0; i < 256; i++) hex.push((i + 0x100).toString(16).slice(1));
-  const s = (i: number) => hex[b[i]];
+  // Format each byte directly. Every byte keeps its own value, so no arithmetic
+  // touches the random data and the distribution is exactly what the CSPRNG gave.
+  const h = (i: number) => b[i].toString(16).padStart(2, "0");
   return (
-    s(0) + s(1) + s(2) + s(3) + "-" + s(4) + s(5) + "-" + s(6) + s(7) + "-" +
-    s(8) + s(9) + "-" + s(10) + s(11) + s(12) + s(13) + s(14) + s(15)
+    h(0) + h(1) + h(2) + h(3) + "-" + h(4) + h(5) + "-" + h(6) + h(7) + "-" +
+    h(8) + h(9) + "-" + h(10) + h(11) + h(12) + h(13) + h(14) + h(15)
   );
 }
 

--- a/frontend/src/lib/randomUuidPolyfill.ts
+++ b/frontend/src/lib/randomUuidPolyfill.ts
@@ -1,0 +1,47 @@
+// `crypto.randomUUID` exists only in a SECURE CONTEXT: HTTPS, or localhost.
+// A self-hosted instance reached over plain HTTP at a LAN address (a NAS at
+// http://192.168.1.10:8005, say) is neither, so the function is simply absent
+// and every `crypto.randomUUID()` call throws a TypeError. The editor and the
+// dashboard mint ids constantly, so on such an instance creating a design fails
+// with no request ever leaving the browser and, because the call sites catch,
+// no console error either.
+//
+// `crypto.getRandomValues` carries no such restriction, so a real v4 UUID is
+// still available; only the convenience wrapper is missing. Installing it keeps
+// every existing `crypto.randomUUID()` call site working unchanged, including
+// the ones inside @hc/* packages.
+//
+// Nothing is replaced when the browser already provides it, so a normal HTTPS
+// deployment runs the native implementation exactly as before.
+
+/** RFC 4122 v4 UUID from CSPRNG bytes, formatted like crypto.randomUUID(). */
+function uuidV4FromRandomValues(getRandomValues: (a: Uint8Array) => Uint8Array): string {
+  const b = getRandomValues(new Uint8Array(16));
+  b[6] = (b[6] & 0x0f) | 0x40; // version 4
+  b[8] = (b[8] & 0x3f) | 0x80; // variant 10xx
+  const hex: string[] = [];
+  for (let i = 0; i < 256; i++) hex.push((i + 0x100).toString(16).slice(1));
+  const s = (i: number) => hex[b[i]];
+  return (
+    s(0) + s(1) + s(2) + s(3) + "-" + s(4) + s(5) + "-" + s(6) + s(7) + "-" +
+    s(8) + s(9) + "-" + s(10) + s(11) + s(12) + s(13) + s(14) + s(15)
+  );
+}
+
+/** Install crypto.randomUUID when the browser withholds it (insecure origin). */
+export function installRandomUuidPolyfill(): void {
+  if (typeof globalThis === "undefined") return;
+  const c = globalThis.crypto as Crypto | undefined;
+  // Present already (HTTPS/localhost, or Node): leave the native one alone.
+  if (!c || typeof c.randomUUID === "function") return;
+  // Without getRandomValues there is no safe source of randomness to fall back
+  // on, and inventing one with Math.random would hand out guessable ids. Better
+  // to leave the call throwing than to silently weaken id generation.
+  if (typeof c.getRandomValues !== "function") return;
+  const getRandomValues = (a: Uint8Array) => c.getRandomValues(a);
+  Object.defineProperty(c, "randomUUID", {
+    value: () => uuidV4FromRandomValues(getRandomValues),
+    configurable: true,
+    writable: true,
+  });
+}

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import "@/styles/globals.css";
+import { installRandomUuidPolyfill } from "@/lib/randomUuidPolyfill";
 import { useEffect } from "react";
 import type { AppProps } from "next/app";
 import { Plus_Jakarta_Sans } from "next/font/google";
@@ -7,6 +8,11 @@ import { watchSystemTheme } from "@/lib/theme";
 import { applyLocale, getLocalePreference, setLocalePreference } from "@/lib/locale";
 import { initI18n, loadCatalog, useI18nVersion } from "@/lib/i18n";
 import { useAuth } from "@/store/auth";
+
+// Runs at import, before any handler can mint an id: an instance served over
+// plain HTTP at a LAN address gets no crypto.randomUUID from the browser, and
+// without this every "create design" style action throws.
+installRandomUuidPolyfill();
 
 // Friendly geometric brand sans, exposed as --font-brand for the design tokens.
 const brand = Plus_Jakarta_Sans({


### PR DESCRIPTION
Fixes the "Could not create design" report in #17.

## Symptom
On a self-hosted instance reached over plain HTTP at a LAN address (a NAS at `http://192.168.1.10:8005`), clicking **Create design** shows "Could not create design", **no network request is made at all**, and the console shows nothing.

## Cause
`crypto.randomUUID` is a **secure-context API**. It exists over HTTPS and on `localhost`, and simply does not exist on `http://<lan-ip>`. Every call throws a `TypeError`.

The dashboard and editor mint ids constantly (**49 call sites**, including `createBlankDesign` in `@hc/schema`), and the call sites `catch`, which is exactly why the failure is invisible: a toast, no request, nothing logged.

This also explains why it reproduced identically in Chrome, Incognito and Edge, and why templates and assets still loaded fine (plain GETs mint no ids).

## Fix
`crypto.getRandomValues` has no secure-context restriction, so a real v4 UUID is still obtainable; only the convenience wrapper is missing. Install it at app import, before any handler can run, so **every existing call site keeps working unchanged**, including those inside `@hc/*` packages.

- A browser that already provides `randomUUID` keeps its native implementation, so an HTTPS deployment is completely untouched.
- If `getRandomValues` is missing too, nothing is installed: guessable ids would be worse than a loud failure.
- No web workers mint ids, so the main-thread install is sufficient.

## Verification
Real production build, driven in headless Chrome over a **non-secure LAN origin**, with the released v0.3.9 as a control:

| Build | `isSecureContext` | `crypto.randomUUID` | POST /designs | Result |
|---|---|---|---|---|
| v0.3.9 (control) | false | `undefined` | **0** | stuck on /dashboard/ (reproduces #17) |
| this PR | false | `function` | **2** | navigates to `/editor/…`, design created |

Unit tests cover the fallback shape (valid v4), uniqueness across 500 ids, not overriding a native implementation, and refusing to invent randomness when `getRandomValues` is absent. Full frontend suite green (50 files, 444 tests).

Pure frontend change: no schema, no SQL, no API change.