### PR TITLE
Make copy-to-clipboard work on an insecure origin

### DIFF
--- a/frontend/src/components/editor/ExportDialog.tsx
+++ b/frontend/src/components/editor/ExportDialog.tsx
@@ -35,6 +35,7 @@ import { imageAssets } from "@/lib/assetProvider";
 import { oc } from "@/lib/sdk";
 import { useToast } from "@/components/ui/Toast";
 import { tr } from "@/lib/i18n";
+import { copyText } from "@/lib/clipboard";
 
 type Format = "png" | "jpg" | "pdf" | "svg" | "apng" | "gif" | "lottie" | "mp4" | "pptx" | "md";
 
@@ -835,7 +836,14 @@ export function ExportDialog({ open, onClose }: { open: boolean; onClose: () => 
             <div className="mb-1 flex items-center justify-between">
               <span className="font-semibold">{tr("editor.credits")}</span>
               <button
-                onClick={() => { void navigator.clipboard.writeText(attributionText(credits)); toast.success(tr("editor.credits_copied")); }}
+                onClick={() => {
+                  // Awaited via copyText so the toast reports what actually
+                  // happened: the old call announced success without waiting,
+                  // and threw outright on an insecure origin.
+                  void copyText(attributionText(credits)).then((ok) =>
+                    ok ? toast.success(tr("editor.credits_copied")) : toast.error(tr("editor.clipboard_unavailable")),
+                  );
+                }}
                 className="text-[11px] font-medium text-brand-ink hover:underline"
               >
                 {tr("editor.copy")}

--- a/frontend/src/components/editor/ShareDialog.tsx
+++ b/frontend/src/components/editor/ShareDialog.tsx
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Copy, Link2, RotateCw, Trash2, Ban, Check, Code, Eye, EyeOff, Lock, Crown, X, UserCheck, ChevronRight, Plus } from "lucide-react";
 import { ApiError } from "@hc/sdk";
 import type { AccessMode, AccessRequestView, DesignSharingView, ShareGrant, ShareLinkView } from "@hc/sdk";
+import { copyText } from "@/lib/clipboard";
 import { oc } from "@/lib/sdk";
 import { useEditor } from "@/store/editor";
 import { Modal } from "@/components/ui/Modal";
@@ -100,34 +101,6 @@ function errMessage(e: unknown, fallback: string): string {
     if (body?.title) return body.title;
   }
   return fallback;
-}
-
-/** Copy text to the clipboard, falling back to a hidden textarea + execCommand
- *  for insecure-context self-hosts where navigator.clipboard is unavailable.
- *  Returns whether the copy succeeded. */
-async function copyText(text: string): Promise<boolean> {
-  try {
-    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(text);
-      return true;
-    }
-  } catch {
-    // fall through to the legacy path
-  }
-  try {
-    const ta = document.createElement("textarea");
-    ta.value = text;
-    ta.style.position = "fixed";
-    ta.style.opacity = "0";
-    document.body.appendChild(ta);
-    ta.focus();
-    ta.select();
-    const ok = document.execCommand("copy");
-    document.body.removeChild(ta);
-    return ok;
-  } catch {
-    return false;
-  }
 }
 
 /** ISO timestamp -> the value a <input type="datetime-local"> expects (local). */

--- a/frontend/src/components/editor/WhiteboardSurface.tsx
+++ b/frontend/src/components/editor/WhiteboardSurface.tsx
@@ -95,6 +95,7 @@ import { getRealtimeClient } from "@/lib/useRealtime";
 import { Canvas } from "./Canvas";
 import { ZoomControl } from "./ZoomControl";
 import { tr } from "@/lib/i18n";
+import { copyText } from "@/lib/clipboard";
 
 // Ephemeral reaction palette: a fixed set of one-shot pings.
 const REACTION_EMOJIS = ["👍", "❤️", "😂", "🎉", "👀", "✅"] as const;
@@ -537,9 +538,13 @@ export function WhiteboardSurface(props: {
       toast.toast(tr("editor.nothing_diagram_shaped_here_yet_add_stickies"), "info");
       return;
     }
-    void navigator.clipboard.writeText(diagramToMermaid(spec)).then(
-      () => toast.success(`Copied ${spec.nodes.length} nodes / ${spec.edges.length} edges as Mermaid.`),
-      () => toast.error(tr("editor.clipboard_unavailable")),
+    // Via copyText: on an insecure origin navigator.clipboard is undefined, so
+    // reading .writeText off it throws before any promise exists and the
+    // rejection handler below would never run.
+    void copyText(diagramToMermaid(spec)).then((ok) =>
+      ok
+        ? toast.success(`Copied ${spec.nodes.length} nodes / ${spec.edges.length} edges as Mermaid.`)
+        : toast.error(tr("editor.clipboard_unavailable")),
     );
   }, [toast]);
 

--- a/frontend/src/lib/clipboard.test.ts
+++ b/frontend/src/lib/clipboard.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+// The insecure-context case is the one that bit a self-hoster: navigator.clipboard
+// is absent over plain HTTP at a LAN address, so touching .writeText throws
+// synchronously and a .then(ok, err) handler never sees it.
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { copyText } from "./clipboard";
+
+const realNavigator = globalThis.navigator;
+const setClipboard = (clipboard: unknown) =>
+  Object.defineProperty(globalThis, "navigator", {
+    value: { ...realNavigator, clipboard },
+    configurable: true,
+    writable: true,
+  });
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "navigator", { value: realNavigator, configurable: true, writable: true });
+  vi.restoreAllMocks();
+});
+
+describe("copyText", () => {
+  it("uses the clipboard api when it is available", async () => {
+    const writeText = vi.fn(async () => {});
+    setClipboard({ writeText });
+    await expect(copyText("hello")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("falls back to execCommand when navigator.clipboard is missing", async () => {
+    setClipboard(undefined); // insecure origin
+    const exec = vi.fn(() => true);
+    Object.defineProperty(document, "execCommand", { value: exec, configurable: true, writable: true });
+
+    await expect(copyText("from a LAN address")).resolves.toBe(true);
+    expect(exec).toHaveBeenCalledWith("copy");
+  });
+
+  it("falls back when the clipboard api rejects", async () => {
+    setClipboard({ writeText: vi.fn(async () => { throw new Error("not focused"); }) });
+    const exec = vi.fn(() => true);
+    Object.defineProperty(document, "execCommand", { value: exec, configurable: true, writable: true });
+
+    await expect(copyText("x")).resolves.toBe(true);
+    expect(exec).toHaveBeenCalled();
+  });
+
+  it("reports failure rather than throwing when nothing can copy", async () => {
+    setClipboard(undefined);
+    Object.defineProperty(document, "execCommand", {
+      value: () => { throw new Error("denied"); },
+      configurable: true,
+      writable: true,
+    });
+    await expect(copyText("x")).resolves.toBe(false);
+  });
+
+  it("leaves no textarea behind after the fallback", async () => {
+    setClipboard(undefined);
+    Object.defineProperty(document, "execCommand", { value: () => true, configurable: true, writable: true });
+    await copyText("tidy");
+    expect(document.querySelectorAll("textarea")).toHaveLength(0);
+  });
+});

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,40 @@
+// Copying text has to keep working on a self-hosted instance reached over plain
+// HTTP at a LAN address. `navigator.clipboard` is a secure-context api, so there
+// it is simply absent, and reading `.writeText` off it throws synchronously,
+// before any promise exists: a `.then(ok, err)` rejection handler never fires
+// for that case, which is how a copy button ends up failing silently.
+//
+// The legacy textarea + execCommand path has no such restriction, so it stands
+// in and the copy genuinely succeeds rather than merely failing politely.
+
+/** Copy text to the clipboard, falling back to a hidden textarea + execCommand
+ *  for insecure-context self-hosts where navigator.clipboard is unavailable.
+ *  Never throws; returns whether the copy succeeded. */
+export async function copyText(text: string): Promise<boolean> {
+  try {
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Permission denied, or the document is not focused: fall through and let
+    // the legacy path try.
+  }
+  let ta: HTMLTextAreaElement | undefined;
+  try {
+    ta = document.createElement("textarea");
+    ta.value = text;
+    ta.style.position = "fixed";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    // In a finally, so a throwing execCommand cannot strand the node: every
+    // failed copy would otherwise leave one more invisible textarea in the DOM.
+    ta?.remove();
+  }
+}


### PR DESCRIPTION
Follow-on from #23. `navigator.clipboard` is a secure-context API too, so the same self-hosters (plain HTTP at a LAN address, as in #17) hit it. Most call sites already handled a missing clipboard; two did not.

## The subtle part
Reading `.writeText` off an **undefined** `navigator.clipboard` throws **synchronously**, before any promise exists, so a `.then(ok, err)` rejection handler never runs:

- **WhiteboardSurface** "copy as Mermaid" had exactly that shape. It *intended* to report a clipboard failure (the error branch was there) and instead threw out of the callback.
- **ExportDialog** credits copy had the same throw, plus a bug unrelated to security context: it never awaited the write and called `toast.success` unconditionally, so a rejected copy still claimed "Credits copied".

## Change
`ShareDialog` already carried a correct helper, guarded, with a textarea + `execCommand` fallback that **works on an insecure origin**. Lifted it to `lib/clipboard.ts` and used it in all three places, so those two paths now *copy successfully* rather than merely failing politely. No new abstraction, one fewer private copy.

## A bug the tests found
Writing cover for it surfaced one more: when `execCommand` **throws**, the old code never reached `removeChild`, stranding an invisible `<textarea>` in the DOM on every failed copy. Removal now happens in a `finally`.

Tests cover the API path, the fallback when the clipboard is missing, the fallback when the API rejects, honest failure when neither works, and no leftover node. Full frontend suite green (449 tests).

Pure frontend change: no schema, no SQL, no API change.